### PR TITLE
add missing symbols on Layout

### DIFF
--- a/experimental/c/chechen_latin/source/chechen_latin.kmn
+++ b/experimental/c/chechen_latin/source/chechen_latin.kmn
@@ -73,8 +73,10 @@ group(detectStartOfSentence) readonly
 
 group(main) using keys
 + any(key) > index(out, 1)
-+ [RALT K_QUOTE] > U+0027
-+ [RALT K_LBRKT] > ';'
++ [RALT K_EQUAL] > '"'
++ [RALT K_HYPHEN] > U+0027
++ [RALT K_0] > ':'
++ [RALT K_9] > ';'
 + [SHIFT RALT K_COLON] > 'Ç̇'
 + [RALT K_COLON] > 'ç̇'
 + [SHIFT K_QUOTE] > 'Ə'

--- a/experimental/c/chechen_latin/source/chechen_latin.kvks
+++ b/experimental/c/chechen_latin/source/chechen_latin.kvks
@@ -23,8 +23,6 @@
       <key vkey="K_G">Ġ</key>
       <key vkey="K_C">Ċ</key>
       <key vkey="K_A">Ä</key>
-      <key vkey="K_QUOTE">'</key>
-      <key vkey="K_LBRKT">;</key>
     </layer>
     <layer shift="RA">
       <key vkey="K_COLON">ç̇</key>
@@ -41,8 +39,10 @@
       <key vkey="K_G">ġ</key>
       <key vkey="K_C">ċ</key>
       <key vkey="K_A">ä</key>
-      <key vkey="K_LBRKT">;</key>
-      <key vkey="K_QUOTE">'</key>
+      <key vkey="K_9">;</key>
+      <key vkey="K_0">:</key>
+      <key vkey="K_HYPHEN">'</key>
+      <key vkey="K_EQUAL">"</key>
     </layer>
     <layer shift="S">
       <key vkey="K_1">!</key>


### PR DESCRIPTION
Fixing the issue https://github.com/chechen-language/keyboards/issues/5

Referring to the [German layout](http://xahlee.info/kbd/ilayout/german_layout_S4Qk.svg), I propose to add the missing two characters under the digital line in combination with AltGr and transfer the two that already exist.

Move `;` from `K_COLON` to `K_9`
Move `'` from `K_QUOTE` to `K_HYPHEN`
Add `:` to `K_0`
Add `"` to `K_EQUAL`

![chechen-latin-full](https://user-images.githubusercontent.com/34921843/180669569-69ab17cb-53a0-49a9-8f7d-da373897e09b.png)

